### PR TITLE
Linux: only parse .desktop files

### DIFF
--- a/src/platforms/linux.rs
+++ b/src/platforms/linux.rs
@@ -136,7 +136,7 @@ pub fn get_all_apps() -> Result<Vec<App>> {
                 continue;
             }
 
-            if path.extension().unwrap() == "desktop" {
+            if path.extension().unwrap() == "desktop" && path.is_file() {
                 let (mut app, has_display) = parse_desktop_file(path.to_path_buf());
                 // fill icon path if .desktop file contains only icon name
                 if !has_display {


### PR DESCRIPTION
Kde names its extensions folders with .desktop at the end e.g. `org.kde.breezetwilight.desktop` which currently just crashes...

I am opening this PR into `dev` since `main` doesn't compile on linux

note:
are there any plans on refactoring the code so it doesn't panic if anything happens and instead e.g ignores the app?